### PR TITLE
fix: 文件列表添加解析完成时间列，修复预览页首次加载markdown不显示

### DIFF
--- a/frontend/src/views/FilePreview.vue
+++ b/frontend/src/views/FilePreview.vue
@@ -262,10 +262,15 @@ onMounted(async () => {
   if (!currentFile.value && allFiles.value.length > 0) {
     currentFile.value = allFiles.value[0]
   }
-  
+
   // 初始化完成
   await nextTick()
   isReady.value = true
+
+  // 如果初始视图模式需要显示 markdown，立即加载内容
+  if (viewMode.value !== 'origin' && currentFile.value) {
+    await fetchParsedContent()
+  }
 })
 
 const filteredFiles = computed(() => allFiles.value)

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -92,6 +92,11 @@
               <span class="cell-text">{{ formatDateTime(row.upload_time) }}</span>
             </template>
           </el-table-column>
+          <el-table-column prop="finish_at" label="解析完成时间" width="160">
+            <template #default="{ row }">
+              <span class="cell-text">{{ formatDateTime(row.finish_at) }}</span>
+            </template>
+          </el-table-column>
           <el-table-column prop="status" label="状态" width="110">
             <template #default="{ row }">
               <div class="status-cell">


### PR DESCRIPTION
- 在文件列表页添加finish_at字段显示解析完成时间
- 修复预览页首次进入时markdown内容不自动加载的问题