### PR TITLE
Fix MinerU router page markdown output

### DIFF
--- a/backend/mineru_api_patch/sitecustomize.py
+++ b/backend/mineru_api_patch/sitecustomize.py
@@ -11,6 +11,8 @@ import builtins
 import json
 import os
 import sys
+import threading
+import time
 import zipfile
 from pathlib import Path
 from types import ModuleType
@@ -19,6 +21,19 @@ from typing import Any
 
 _PATCHED = False
 _ORIGINAL_IMPORT = builtins.__import__
+_INCOMPATIBLE_LOGGED: set[str] = set()
+
+
+def _module_label(module: ModuleType) -> str:
+    spec = getattr(module, "__spec__", None)
+    spec_name = getattr(spec, "name", None)
+    if spec_name and spec_name != getattr(module, "__name__", ""):
+        return f"{module.__name__} ({spec_name})"
+    return getattr(module, "__name__", "<unknown>")
+
+
+def _log(level: str, message: str) -> None:
+    print(f"### MINERU-WEB-PAGES-PATCH ### {level}: {message}", file=sys.stderr, flush=True)
 
 
 def _page_heading(page_info: dict[str, Any], fallback_index: int) -> str:
@@ -76,15 +91,31 @@ def _ensure_pages_markdown(parse_dir: str, pdf_name: str) -> Path | None:
     return pages_path
 
 
-def _patch_fast_api(module: ModuleType) -> None:
+def _patch_fast_api(module: ModuleType, *, log_missing: bool = False) -> None:
     global _PATCHED
-    if _PATCHED or getattr(module, "_mineru_web_pages_patch", False):
+    if getattr(module, "_mineru_web_pages_patch", False):
         return
 
     original_create_result_zip = getattr(module, "create_result_zip", None)
     get_parse_dir = getattr(module, "get_parse_dir", None)
     build_zip_arcname = getattr(module, "build_zip_arcname", None)
     if not original_create_result_zip or not get_parse_dir or not build_zip_arcname:
+        module_label = _module_label(module)
+        if log_missing and module_label not in _INCOMPATIBLE_LOGGED:
+            missing = [
+                name
+                for name, value in (
+                    ("create_result_zip", original_create_result_zip),
+                    ("get_parse_dir", get_parse_dir),
+                    ("build_zip_arcname", build_zip_arcname),
+                )
+                if not value
+            ]
+            _log(
+                "WARNING",
+                f"patch not applied to {module_label}; missing MinerU hook(s): {', '.join(missing)}",
+            )
+            _INCOMPATIBLE_LOGGED.add(module_label)
         return
 
     def create_result_zip_with_pages(
@@ -140,12 +171,38 @@ def _patch_fast_api(module: ModuleType) -> None:
     module.create_result_zip = create_result_zip_with_pages
     module._mineru_web_pages_patch = True
     _PATCHED = True
+    _log("INFO", f"patched create_result_zip in {_module_label(module)}")
 
 
-def _try_patch_loaded_fast_api() -> None:
-    module = sys.modules.get("mineru.cli.fast_api")
-    if module:
-        _patch_fast_api(module)
+def _fast_api_modules() -> list[ModuleType]:
+    modules = [sys.modules.get("mineru.cli.fast_api")]
+    main_module = sys.modules.get("__main__")
+    main_spec = getattr(main_module, "__spec__", None)
+    if getattr(main_spec, "name", None) == "mineru.cli.fast_api":
+        modules.append(main_module)
+    return [module for module in modules if module]
+
+
+def _try_patch_loaded_fast_api(*, log_missing: bool = False) -> None:
+    for module in _fast_api_modules():
+        _patch_fast_api(module, log_missing=log_missing)
+
+
+def _watch_fast_api_main() -> None:
+    saw_fast_api_module = False
+    for _ in range(300):
+        if _fast_api_modules():
+            saw_fast_api_module = True
+        _try_patch_loaded_fast_api()
+        time.sleep(0.1)
+    if saw_fast_api_module and not _PATCHED:
+        _try_patch_loaded_fast_api(log_missing=True)
+        _log("WARNING", "patch watcher expired before MinerU fast_api create_result_zip was patched")
+
+
+def _start_fast_api_main_watcher() -> None:
+    thread = threading.Thread(target=_watch_fast_api_main, name="mineru-web-pages-patch", daemon=True)
+    thread.start()
 
 
 def _import_with_patch(name, globals=None, locals=None, fromlist=(), level=0):
@@ -158,3 +215,4 @@ def _import_with_patch(name, globals=None, locals=None, fromlist=(), level=0):
 if os.getenv("MINERU_WEB_DISABLE_PAGES_PATCH", "").lower() not in {"1", "true", "yes"}:
     builtins.__import__ = _import_with_patch
     _try_patch_loaded_fast_api()
+    _start_fast_api_main_watcher()

--- a/backend/tests/test_mineru_api_pages_patch.py
+++ b/backend/tests/test_mineru_api_pages_patch.py
@@ -3,6 +3,7 @@ import io
 import json
 import sys
 import zipfile
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 from types import ModuleType
 
@@ -107,3 +108,50 @@ def test_pages_patch_renders_pages_with_backend_aware_mineru_renderer(monkeypatc
         ("vlm", "mm_md", "images", 0),
         ("vlm", "mm_md", "images", 2),
     ]
+
+
+def test_pages_patch_patches_fast_api_run_as_main(monkeypatch):
+    patch = load_patch_module(monkeypatch)
+    fake_main = ModuleType("__main__")
+    fake_main.__spec__ = ModuleSpec("__main__", loader=None)
+    fake_main.__spec__.name = "mineru.cli.fast_api"
+    fake_main.create_result_zip = lambda *args, **kwargs: "result.zip"
+    fake_main.get_parse_dir = lambda output_dir, pdf_name, backend, parse_method: output_dir
+    fake_main.build_zip_arcname = lambda pdf_name, parse_dir_arg, rel: f"{pdf_name}/{rel}"
+
+    monkeypatch.setitem(sys.modules, "__main__", fake_main)
+
+    patch._try_patch_loaded_fast_api()
+
+    assert getattr(fake_main, "_mineru_web_pages_patch", False) is True
+    assert fake_main.create_result_zip.__name__ == "create_result_zip_with_pages"
+
+
+def test_pages_patch_logs_success(capsys, monkeypatch):
+    patch = load_patch_module(monkeypatch)
+    fake_fast_api = ModuleType("mineru.cli.fast_api")
+    fake_fast_api.create_result_zip = lambda *args, **kwargs: "result.zip"
+    fake_fast_api.get_parse_dir = lambda output_dir, pdf_name, backend, parse_method: output_dir
+    fake_fast_api.build_zip_arcname = lambda pdf_name, parse_dir_arg, rel: f"{pdf_name}/{rel}"
+
+    patch._patch_fast_api(fake_fast_api)
+
+    captured = capsys.readouterr()
+    assert "### MINERU-WEB-PAGES-PATCH ###" in captured.err
+    assert "patched create_result_zip" in captured.err
+    assert "mineru.cli.fast_api" in captured.err
+
+
+def test_pages_patch_logs_incompatible_fast_api_once(capsys, monkeypatch):
+    patch = load_patch_module(monkeypatch)
+    fake_fast_api = ModuleType("mineru.cli.fast_api")
+
+    patch._patch_fast_api(fake_fast_api, log_missing=True)
+    patch._patch_fast_api(fake_fast_api, log_missing=True)
+
+    captured = capsys.readouterr()
+    assert "### MINERU-WEB-PAGES-PATCH ###" in captured.err
+    assert captured.err.count("patch not applied") == 1
+    assert "create_result_zip" in captured.err
+    assert "get_parse_dir" in captured.err
+    assert "build_zip_arcname" in captured.err

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,9 @@ services:
       # configured *-http-client backends/server_url can work.
       - --allow-public-http-client
     volumes:
+      # Runtime patch is bind-mounted so page-aware Markdown fixes can be
+      # deployed with a container restart instead of rebuilding the MinerU image.
+      - ./backend/mineru_api_patch:/app/mineru_api_patch:ro
       - mineru_api_output:/output
     ulimits:
       memlock: -1

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -160,6 +160,7 @@ docker compose --env-file .env -f docker-compose.yml -f docker-compose.gpu.local
 - 构建阶段安装 `mineru[core]==3.3.1`。
 - 构建阶段执行 `mineru-models-download -m all` 下载模型。
 - 默认启动命令使用 `mineru-router --local-gpus auto`。
+- `docker-compose.yml` 会把 `backend/mineru_api_patch` 挂载到 `/app/mineru_api_patch`，运行时 patch 更新后重启 `mineru-router` 即可生效，不需要为 patch 变更重打 MinerU 镜像。
 
 如果宿主机 CUDA 驱动不兼容默认 base image，可以按 Dockerfile 注释切换到 `vllm/vllm-openai:v0.21.0-cu129` 后重新构建 parser 镜像。
 


### PR DESCRIPTION
## Summary
- Patch MinerU fast_api when it is launched via `python -m mineru.cli.fast_api`, where the runtime module is `__main__`.
- Add explicit `### MINERU-WEB-PAGES-PATCH ###` logs for patch success and incompatibility diagnostics.
- Bind-mount `backend/mineru_api_patch` into `mineru-router` so patch updates only need a container restart, not a MinerU image rebuild.

## Test Plan
- `docker compose exec -T backend python3 -m pytest tests/test_mineru_api_pages_patch.py -q`
- Restarted `mineru-router` and confirmed startup log includes `### MINERU-WEB-PAGES-PATCH ### INFO: patched create_result_zip in __main__ (mineru.cli.fast_api)`
- Direct `/file_parse` against `127.0.0.1:8002` returns ZIP entries including `test/auto/test_pages.md` and `HAS_PAGES=True`
- Uploaded `backend/tests/test.pdf` through the app API and confirmed `GET /api/files/2/parsed_content?variant=markdown_page` returns `200 OK`

Fixes #35
Refs #34
