### PR TITLE
feat(popo): 文档结构树预览与 JSON 下载

### DIFF
--- a/backend/app/api/parsed.py
+++ b/backend/app/api/parsed.py
@@ -54,6 +54,10 @@ def _popo_status_path(file: FileModel) -> str:
     return f"{_artifact_stem(file)}_popo_status.json"
 
 
+def _popo_tree_path(file: FileModel) -> str:
+    return f"{_artifact_stem(file)}_popo.json"
+
+
 def _middle_json_candidates(file: FileModel) -> list[str]:
     stem = _artifact_stem(file)
     return [
@@ -519,6 +523,33 @@ def get_popo_status(
     except Exception as e:
         if _is_missing_object_error(e):
             return {"status": "not_available", "message": ""}
+        raise HTTPException(status_code=500, detail=str(e))
+
+    try:
+        return json.loads(content)
+    except json.JSONDecodeError as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/files/{file_id}/popo/tree")
+def get_popo_tree(
+    file_id: int,
+    user_id: str = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """返回 Popo 后处理生成的文档结构树（{stem}_popo.json）。"""
+    file = db.query(FileModel).filter(FileModel.id == file_id, FileModel.user_id == user_id).first()
+    if not file:
+        raise HTTPException(status_code=404, detail="文件不存在")
+
+    buckets = get_buckets()
+    mds_bucket = buckets[0]
+
+    try:
+        content = _read_minio_object(mds_bucket, _popo_tree_path(file)).decode("utf-8")
+    except Exception as e:
+        if _is_missing_object_error(e):
+            raise HTTPException(status_code=404, detail="Popo 结构树不存在")
         raise HTTPException(status_code=500, detail=str(e))
 
     try:

--- a/backend/tests/test_export_api.py
+++ b/backend/tests/test_export_api.py
@@ -60,6 +60,7 @@ class FakeMinio:
             ("mds", "sample_pages.md"): b"# Pages",
             ("mds", "sample_popo.md"): b"# Popo",
             ("mds", "sample_popo_status.json"): b'{"status":"success","message":""}',
+            ("mds", "sample_popo.json"): b'{"type":"root","children":[{"type":"title","title":"\xe7\xab\xa0\xe8\x8a\x82"}]}',
         }
 
     def stat_object(self, bucket, path):
@@ -426,6 +427,60 @@ def test_popo_status_returns_status_json(monkeypatch):
     assert response.json() == {"status": "success", "message": ""}
     assert fake_minio.get_responses[0].closed is True
     assert fake_minio.get_responses[0].released is True
+
+
+def test_popo_tree_returns_parsed_json(monkeypatch):
+    fake_file = SimpleNamespace(
+        id=3,
+        user_id="u1",
+        filename="sample.pdf",
+        minio_path="uploads/sample.pdf",
+    )
+    fake_minio = FakeMinio()
+
+    app.dependency_overrides[get_db] = lambda: FakeDb(fake_file)
+    monkeypatch.setattr("app.api.parsed.get_buckets", lambda: ["mds"])
+    monkeypatch.setattr("app.api.parsed.minio_client", fake_minio)
+
+    try:
+        response = TestClient(app).get(
+            "/api/files/3/popo/tree",
+            headers={"X-User-Id": "u1"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "type": "root",
+        "children": [{"type": "title", "title": "章节"}],
+    }
+    assert fake_minio.get_calls == [("mds", "sample_popo.json")]
+
+
+def test_popo_tree_returns_404_when_artifact_missing(monkeypatch):
+    fake_file = SimpleNamespace(
+        id=3,
+        user_id="u1",
+        filename="sample.pdf",
+        minio_path="uploads/sample.pdf",
+    )
+    fake_minio = FakeMinio()
+    del fake_minio.existing_objects[("mds", "sample_popo.json")]
+
+    app.dependency_overrides[get_db] = lambda: FakeDb(fake_file)
+    monkeypatch.setattr("app.api.parsed.get_buckets", lambda: ["mds"])
+    monkeypatch.setattr("app.api.parsed.minio_client", fake_minio)
+
+    try:
+        response = TestClient(app).get(
+            "/api/files/3/popo/tree",
+            headers={"X-User-Id": "u1"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 404
 
 
 def test_popo_status_returns_not_available_when_artifact_missing(monkeypatch):

--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -1,6 +1,6 @@
 import api from './index'
 import type { AxiosProgressEvent } from 'axios'
-import type { FileItem, ExportFormat, FolderItem, MarkdownVariant, PopoStatus, SourceMap } from '@/types/file'
+import type { FileItem, ExportFormat, FolderItem, MarkdownVariant, PopoStatus, PopoTreeNode, SourceMap } from '@/types/file'
 
 // 文件列表参数
 export interface FileListParams {
@@ -145,6 +145,14 @@ export const filesApi = {
    */
   getPopoStatus(fileId: string) {
     return api.get<PopoStatus>(`/files/${fileId}/popo/status`)
+      .then(res => res.data)
+  },
+
+  /**
+   * 获取 Popo 文档结构树
+   */
+  getPopoTree(fileId: string) {
+    return api.get<PopoTreeNode>(`/files/${fileId}/popo/tree`)
       .then(res => res.data)
   },
 

--- a/frontend/src/components/PopoTreeView.vue
+++ b/frontend/src/components/PopoTreeView.vue
@@ -1,0 +1,272 @@
+<template>
+  <div class="popo-tree">
+    <div class="popo-tree-toolbar">
+      <div class="popo-tree-stats">
+        <span class="stat-chip">节点 {{ stats.total }}</span>
+        <span class="stat-chip">标题 {{ stats.title }}</span>
+        <span class="stat-chip">表格 {{ stats.table }}</span>
+        <span class="stat-chip">图片 {{ stats.image }}</span>
+      </div>
+      <div class="popo-tree-actions">
+        <el-input
+          v-model="keyword"
+          size="small"
+          placeholder="筛选标题/内容"
+          clearable
+          class="popo-tree-filter"
+        />
+        <el-button size="small" @click="expandAll(true)">展开全部</el-button>
+        <el-button size="small" @click="expandAll(false)">折叠全部</el-button>
+        <el-button size="small" type="primary" :icon="Download" @click="downloadJson">下载 JSON</el-button>
+      </div>
+    </div>
+
+    <el-tree
+      ref="treeRef"
+      class="popo-tree-body"
+      :data="treeData"
+      :props="treeProps"
+      node-key="__id"
+      :default-expand-all="true"
+      :filter-node-method="filterNode"
+      :expand-on-click-node="false"
+    >
+      <template #default="{ data }">
+        <div class="popo-node">
+          <span class="popo-node-type" :class="`type-${typeClass(data.type)}`">
+            {{ typeLabel(data.type) }}
+          </span>
+          <span v-if="data.title && !isPlaceholderTitle(data.title)" class="popo-node-title">
+            {{ data.title }}
+          </span>
+          <span v-if="data.type === 'table'" class="popo-node-extra">
+            <span class="popo-node-badge">{{ data.content ? 'HTML' : '空' }}</span>
+          </span>
+          <span
+            v-else-if="data.content"
+            class="popo-node-preview"
+          >{{ preview(data.content) }}</span>
+        </div>
+      </template>
+    </el-tree>
+
+    <div v-if="!treeData.length" class="popo-tree-empty">结构树为空</div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+import { Download } from '@element-plus/icons-vue'
+import type { PopoTreeNode } from '@/types/file'
+
+interface KeyedNode extends PopoTreeNode {
+  __id: string
+  children?: KeyedNode[]
+}
+
+const props = defineProps<{
+  tree: PopoTreeNode | null
+  filename?: string
+}>()
+
+const treeRef = ref<{ filter: (value: string) => void; store: { nodesMap: Record<string, { expanded: boolean }> } } | null>(null)
+const keyword = ref('')
+
+const treeProps = { children: 'children', label: 'title' }
+
+// 给每个节点分配稳定 key，并把 root 摊平成顶层数组
+const keyed = computed<KeyedNode[]>(() => {
+  if (!props.tree) return []
+  let counter = 0
+  const assign = (node: PopoTreeNode): KeyedNode => {
+    const id = `n${counter++}`
+    const children = (node.children || []).map(assign)
+    return { ...node, __id: id, children }
+  }
+  const root = assign(props.tree)
+  return root.type === 'root' ? (root.children || []) : [root]
+})
+
+const treeData = computed(() => keyed.value)
+
+const stats = computed(() => {
+  const acc = { total: 0, title: 0, table: 0, image: 0 }
+  const walk = (nodes: KeyedNode[]) => {
+    for (const node of nodes) {
+      acc.total += 1
+      if (node.type === 'title' || (node.type === 'text' && node.title && !isPlaceholderTitle(node.title))) {
+        acc.title += 1
+      }
+      if (node.type === 'table') acc.table += 1
+      if (['image', 'chart', 'seal', 'image_block'].includes(node.type)) acc.image += 1
+      if (node.children?.length) walk(node.children)
+    }
+  }
+  walk(keyed.value)
+  return acc
+})
+
+const TYPE_LABELS: Record<string, string> = {
+  text: '正文',
+  title: '标题',
+  table: '表格',
+  image: '图片',
+  chart: '图表',
+  seal: '印章',
+  image_block: '图块',
+  page_title: '页眉标题',
+  page_number: '页码',
+  page_footnote: '脚注',
+  header: '页眉',
+  footer: '页脚',
+  aside_text: '边栏'
+}
+
+const typeLabel = (type: string) => TYPE_LABELS[type] || type || '节点'
+
+const typeClass = (type: string) => {
+  if (type === 'title') return 'title'
+  if (type === 'table') return 'table'
+  if (['image', 'chart', 'seal', 'image_block'].includes(type)) return 'image'
+  return 'text'
+}
+
+const isPlaceholderTitle = (title?: string) => !title || title === 'Default Title' || title === 'N/A'
+
+const preview = (content?: string) => {
+  const text = (content || '').replace(/<\|txt_(split|contd)\|>/g, ' ').replace(/\s+/g, ' ').trim()
+  return text.length > 80 ? `${text.slice(0, 80)}…` : text
+}
+
+const filterNode = (value: string, data: KeyedNode) => {
+  if (!value) return true
+  const haystack = `${data.title || ''} ${data.content || ''}`.toLowerCase()
+  return haystack.includes(value.toLowerCase())
+}
+
+watch(keyword, (value) => {
+  treeRef.value?.filter(value)
+})
+
+const expandAll = (expand: boolean) => {
+  const nodesMap = treeRef.value?.store?.nodesMap
+  if (!nodesMap) return
+  Object.values(nodesMap).forEach((node) => {
+    node.expanded = expand
+  })
+}
+
+const downloadJson = () => {
+  if (!props.tree) return
+  const blob = new Blob([JSON.stringify(props.tree, null, 2)], { type: 'application/json' })
+  const url = window.URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = `${props.filename || 'document'}_popo.json`
+  document.body.appendChild(link)
+  link.click()
+  window.URL.revokeObjectURL(url)
+  document.body.removeChild(link)
+}
+</script>
+
+<style scoped>
+.popo-tree {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.popo-tree-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--el-border-color-lighter, #ebeef5);
+}
+
+.popo-tree-stats {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.stat-chip {
+  font-size: 12px;
+  color: var(--el-text-color-regular, #606266);
+  background: var(--el-fill-color-light, #f5f7fa);
+  border-radius: 10px;
+  padding: 2px 10px;
+}
+
+.popo-tree-actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.popo-tree-filter {
+  width: 160px;
+}
+
+.popo-tree-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 8px 12px;
+}
+
+.popo-node {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+}
+
+.popo-node-type {
+  flex: none;
+  font-size: 11px;
+  line-height: 18px;
+  padding: 0 8px;
+  border-radius: 4px;
+  color: #fff;
+}
+
+.type-title { background: #409eff; }
+.type-table { background: #e6a23c; }
+.type-image { background: #67c23a; }
+.type-text { background: #909399; }
+
+.popo-node-title {
+  font-weight: 600;
+  color: var(--el-text-color-primary, #303133);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.popo-node-preview {
+  color: var(--el-text-color-secondary, #909399);
+  font-size: 12px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.popo-node-badge {
+  font-size: 11px;
+  color: var(--el-text-color-regular, #606266);
+  border: 1px solid var(--el-border-color, #dcdfe6);
+  border-radius: 4px;
+  padding: 0 6px;
+}
+
+.popo-tree-empty {
+  padding: 24px;
+  text-align: center;
+  color: var(--el-text-color-secondary, #909399);
+}
+</style>

--- a/frontend/src/types/file.ts
+++ b/frontend/src/types/file.ts
@@ -74,6 +74,18 @@ export interface SourceMap {
   pages: SourcePage[]
 }
 
+// Popo 后处理生成的文档结构树节点
+export interface PopoTreeNode {
+  type: string
+  title?: string
+  metadata?: string
+  content?: string
+  level?: number
+  location?: Array<{ bbox?: number[]; page?: number }>
+  block_ids?: number[]
+  children?: PopoTreeNode[]
+}
+
 // 导出格式显示名称
 export const ExportFormatNames: Record<ExportFormat, string> = {
   [ExportFormats.MARKDOWN]: 'Markdown',

--- a/frontend/src/views/FilePreview.vue
+++ b/frontend/src/views/FilePreview.vue
@@ -114,8 +114,8 @@
       <!-- 预览内容区 -->
       <div class="preview-content">
         <!-- 原文件预览 -->
-        <div 
-          v-if="viewMode !== 'markdown' && markdownVariant !== 'compare'"
+        <div
+          v-if="viewMode !== 'markdown' && markdownVariant !== 'compare' && markdownVariant !== 'popo_tree'"
           class="preview-panel origin-panel"
           :class="{ 'full-width': viewMode === 'origin' }"
         >
@@ -168,14 +168,14 @@
         <div 
           v-if="viewMode !== 'origin'" 
           class="preview-panel markdown-panel"
-          :class="{ 'full-width': viewMode === 'markdown' || markdownVariant === 'compare' }"
+          :class="{ 'full-width': viewMode === 'markdown' || markdownVariant === 'compare' || markdownVariant === 'popo_tree' }"
         >
           <div class="panel-content">
             <div v-if="isPdf(currentFile?.filename)" class="pdf-review-bar">
               <div class="pdf-review-title">
-                <span>{{ markdownVariant === 'compare' ? 'OCR / Popo 对照' : 'Markdown 预览' }}</span>
+                <span>{{ pdfReviewTitle }}</span>
                 <small>
-                  {{ markdownVariant === 'compare' ? '原始 OCR 结果 / Popo 增强结果' : `Page ${activeSourcePage} / ${pageSections.length || 0}` }}
+                  {{ markdownVariant === 'compare' ? '原始 OCR 结果 / Popo 增强结果' : markdownVariant === 'popo_tree' ? 'Popo 文档结构树' : `Page ${activeSourcePage} / ${pageSections.length || 0}` }}
                 </small>
               </div>
               <div class="pdf-review-actions">
@@ -188,9 +188,9 @@
                 >
                   {{ name }}
                 </button>
-                <span v-if="markdownVariant !== 'compare'" class="source-trace-chip">{{ sourceTraceLabel }}</span>
+                <span v-if="markdownVariant !== 'compare' && markdownVariant !== 'popo_tree'" class="source-trace-chip">{{ sourceTraceLabel }}</span>
               </div>
-              <div v-if="markdownVariant !== 'compare' && sourceBlockTotal" class="source-type-filters">
+              <div v-if="markdownVariant !== 'compare' && markdownVariant !== 'popo_tree' && sourceBlockTotal" class="source-type-filters">
                 <button
                   v-for="option in sourceTypeFilterOptions"
                   :key="option.key"
@@ -250,6 +250,16 @@
             </div>
             <el-empty
               v-else-if="markdownVariant === 'popo' && !parsedContent"
+              :description="popoEmptyDescription"
+              :image-size="100"
+            />
+            <PopoTreeView
+              v-else-if="markdownVariant === 'popo_tree' && popoTree"
+              :tree="popoTree"
+              :filename="downloadStem"
+            />
+            <el-empty
+              v-else-if="markdownVariant === 'popo_tree'"
               :description="popoEmptyDescription"
               :image-size="100"
             />
@@ -328,12 +338,14 @@ import * as XLSX from 'xlsx'
 import api from '@/api'
 import { filesApi } from '@/api/files'
 import PdfSourceViewer from '@/components/PdfSourceViewer.vue'
+import PopoTreeView from '@/components/PopoTreeView.vue'
 import {
   ExportFormatNames,
   type ExportFormat,
   type MarkdownVariant,
   type PopoStatus,
   type PopoStatusValue,
+  type PopoTreeNode,
   type SourceBlock,
   type SourceMap
 } from '@/types/file'
@@ -385,7 +397,7 @@ interface PdfSourceViewerRef {
   scrollToBlock: (pageNumber: number, blockId: string) => Promise<void> | void
 }
 
-type MarkdownViewVariant = MarkdownVariant | 'compare'
+type MarkdownViewVariant = MarkdownVariant | 'compare' | 'popo_tree'
 
 const sidebarCollapsed = ref(false)
 const allFiles = ref<FileItem[]>([])
@@ -488,6 +500,7 @@ const selectFile = (file: FileItem) => {
   page.value = 1
   markdownVariant.value = preferredMarkdownVariant(file)
   popoStatus.value = null
+  popoTree.value = null
   parsedContent.value = ''
   markdownLoadError.value = ''
   originLoadError.value = ''
@@ -522,6 +535,12 @@ const hasMore = ref(true)
 let markdownRequestSeq = 0
 const markdownVariant = ref<MarkdownViewVariant>('markdown')
 const popoStatus = ref<PopoStatus | null>(null)
+const popoTree = ref<PopoTreeNode | null>(null)
+const downloadStem = computed(() => {
+  const name = currentFile.value?.filename || 'document'
+  const dot = name.lastIndexOf('.')
+  return dot > 0 ? name.slice(0, dot) : name
+})
 const compareMarkdownContent = ref('')
 const comparePopoContent = ref('')
 const comparePopoStatus = ref<PopoStatus | null>(null)
@@ -529,10 +548,12 @@ const markdownVariantNames: Record<MarkdownViewVariant, string> = {
   markdown: '原始 Markdown',
   markdown_page: '按页 Markdown',
   popo: 'Popo 增强',
+  popo_tree: '结构树',
   compare: '对比'
 }
-const pdfMarkdownVariantNames: Record<'markdown_page' | 'compare', string> = {
+const pdfMarkdownVariantNames: Record<'markdown_page' | 'popo_tree' | 'compare', string> = {
   markdown_page: '溯源阅读',
+  popo_tree: '结构树',
   compare: 'OCR-Popo 对照'
 }
 const popoStatusNames: Record<PopoStatusValue, string> = {
@@ -545,6 +566,11 @@ const popoStatusNames: Record<PopoStatusValue, string> = {
 const popoEmptyDescription = computed(() => {
   if (!popoStatus.value) return 'Popo 结果暂不可用'
   return popoStatus.value.message || popoStatusNames[popoStatus.value.status]
+})
+const pdfReviewTitle = computed(() => {
+  if (markdownVariant.value === 'compare') return 'OCR / Popo 对照'
+  if (markdownVariant.value === 'popo_tree') return '结构树'
+  return 'Markdown 预览'
 })
 const comparePopoEmptyDescription = computed(() => {
   if (!comparePopoStatus.value) return 'Popo 结果暂不可用'
@@ -779,6 +805,10 @@ const fetchParsedContent = async () => {
     await fetchCompareContent()
     return
   }
+  if (markdownVariant.value === 'popo_tree') {
+    await fetchPopoTree()
+    return
+  }
   const fileId = currentFile.value.id
   const variant = markdownVariant.value as MarkdownVariant
   const seq = ++markdownRequestSeq
@@ -821,6 +851,30 @@ const fetchPopoStatus = async (
   } catch (e) {
     if (!isLatestMarkdownRequest(seq, fileId, variant)) return
     popoStatus.value = { status: 'not_available', message: '' }
+  }
+}
+
+const fetchPopoTree = async () => {
+  if (!currentFile.value) return
+  const fileId = currentFile.value.id
+  const variant: MarkdownViewVariant = 'popo_tree'
+  const seq = ++markdownRequestSeq
+  loading.value = true
+  markdownLoadError.value = ''
+  popoTree.value = null
+  popoStatus.value = null
+  try {
+    const data = await filesApi.getPopoTree(fileId)
+    if (!isLatestMarkdownRequest(seq, fileId, variant)) return
+    popoTree.value = data || null
+  } catch (e) {
+    if (!isLatestMarkdownRequest(seq, fileId, variant)) return
+    popoTree.value = null
+    await fetchPopoStatus(fileId, seq, variant)
+  } finally {
+    if (isLatestMarkdownRequest(seq, fileId, variant)) {
+      loading.value = false
+    }
   }
 }
 


### PR DESCRIPTION
## 背景

popo 后处理的核心价值是**文档结构**(标题层级、段落合并、跨页表格归并),但这些通过扁平的 markdown 很难直观体现——结构上的优点是隐形的,而图表位置等弱点反而刺眼。本 PR 增加一个**结构树视图**,直接渲染 `_popo.json`,让 popo 重组后的层级一目了然,并支持下载。

> 依赖已合并的 #37(表格/图片恢复 + vLLM 适配)。

## 改动

**后端** (`backend/app/api/parsed.py`)
- 新增 `GET /files/{file_id}/popo/tree`:读取 `{stem}_popo.json` 返回结构树 JSON,缺失返回 404
- 补 2 个端点测试(成功 / 缺失 404)

**前端**
- `api/files.ts`:`getPopoTree(fileId)`
- `types/file.ts`:`PopoTreeNode` 类型
- **新组件 `components/PopoTreeView.vue`**:`el-tree` 渲染层级,节点带类型彩色徽章(标题/正文/表格/图片)、标题、正文摘要;表格节点标注 `HTML`/`空`;顶部统计条 + 关键词筛选 + 展开/折叠全部 + **下载 JSON**(客户端 Blob,`{文件名}_popo.json`)
- `views/FilePreview.vue`:新增「结构树」视图变体,PDF / 非 PDF 工具栏均可切换,选中时全宽渲染;树不可用时回退到 Popo 状态空态

## 价值

把 popo 的结构化成果(标题层级、段落/跨页表格合并、图文归属)用「树」这个对的镜头展示出来,也方便下游直接拿 `_popo.json` 做按结构分块的检索。节点内容仍受恢复逻辑约束(图片型表格显示「空」、图片需配 `POPO_IMAGE_BASE_URL`),树视图会如实标注这些状态,反而利于排查。

## 测试

- 前端 `vue-tsc -b` + `vite build` 通过
- 后端新端点测试 2 passed;其余测试无回归(仅 1 个预先存在的无关失败 `test_export_endpoint_rejects_popo_format`)
