### PR TITLE
fix(files): 批量选择在轮询刷新后保持不丢

### DIFF
--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -114,6 +114,7 @@
       <!-- 文件表格 -->
       <div class="table-wrapper">
         <el-table
+          ref="tableRef"
           :data="files"
           v-if="files && files.length > 0 && !loading"
           row-key="id"
@@ -307,6 +308,7 @@ const exportingId = ref<string>('')
 const batchExporting = ref(false)
 const batchDeleting = ref(false)
 const multipleSelection = ref<FileItem[]>([])
+const tableRef = ref<{ clearSelection: () => void } | null>(null)
 const router = useRouter()
 const route = useRoute()
 
@@ -684,6 +686,9 @@ const handleBatchDelete = async () => {
       } else {
         ElMessage.error('所有文件删除失败')
       }
+      // 清掉 el-table 的预留选中（reserve-selection 会保留已删除行的 key）
+      tableRef.value?.clearSelection()
+      multipleSelection.value = []
       fetchFiles()
     } finally {
       batchDeleting.value = false

--- a/frontend/src/views/Files.vue
+++ b/frontend/src/views/Files.vue
@@ -113,13 +113,14 @@
 
       <!-- 文件表格 -->
       <div class="table-wrapper">
-        <el-table 
-          :data="files" 
-          v-if="files && files.length > 0 && !loading" 
+        <el-table
+          :data="files"
+          v-if="files && files.length > 0 && !loading"
+          row-key="id"
           @selection-change="handleSelectionChange"
           :header-cell-style="{ background: 'var(--bg-tertiary)', color: 'var(--text-primary)', fontWeight: 600 }"
         >
-          <el-table-column type="selection" width="48" />
+          <el-table-column type="selection" width="48" :reserve-selection="true" />
           <el-table-column prop="filename" label="文件名称" min-width="220">
             <template #default="{ row }">
               <div class="file-name-cell">
@@ -570,13 +571,17 @@ const clearSearchTimer = () => {
 }
 
 const updateFiles = (newFiles: FileItem[]) => {
-  const shouldReplaceList = files.value.length !== newFiles.length
-    || files.value.some((oldFile, index) => oldFile.id !== newFiles[index]?.id)
-  if (shouldReplaceList) {
-    files.value = newFiles
-    return
-  }
-  files.value = newFiles
+  // 原地合并：存活行复用原对象引用（仅更新字段），新增行追加，删除行剔除。
+  // 保留引用可避免轮询刷新时 el-table 丢失多选勾选。
+  const existingById = new Map(files.value.map((file) => [file.id, file]))
+  files.value = newFiles.map((newFile) => {
+    const existing = existingById.get(newFile.id)
+    if (existing) {
+      Object.assign(existing, newFile)
+      return existing
+    }
+    return newFile
+  })
 }
 
 const startPolling = () => {


### PR DESCRIPTION
## 问题

文件管理页勾选多个文件做批量删除/导出时,过几秒勾选会自动取消。

## 根因

文件列表每隔一个轮询周期调用 `getFiles` 刷新(用于更新解析进度),`updateFiles` 实际上每次都把 `files` 数组整体替换成 API 返回的全新对象(原 `shouldReplaceList` 两个分支等价,是死代码)。

`el-table` 在 `:data` 换成**新数组引用**时,若未开启 `reserve-selection`,内部 `setData` 会直接 `clearSelection()` 清空选中 → 触发 `selection-change([])` → `multipleSelection` 被清空 → 勾选消失。

## 修复(`frontend/src/views/Files.vue`)

- 选择列加 `:reserve-selection="true"`,表格加 `row-key="id"`:刷新后 el-table 按 id 重新应用选中(Element Plus 官方的跨刷新保留选中机制)。
- `updateFiles` 改为原地合并:存活行复用原对象引用、仅更新字段,新增追加、删除剔除,替代原来无意义的整体替换。

## 验证

- 本地 docker 栈实测:勾选后经过多个轮询周期(解析中文件进度持续刷新),勾选保持不丢。
- `vue-tsc -b` 类型检查通过,前端构建通过。
